### PR TITLE
arekinath/node-cueball#1 recovery assertions a little too aggressive

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,8 +30,8 @@ function assertRecovery(obj, name) {
 	delete (ks.timeout);
 	mod_assert.optionalNumber(obj.maxTimeout, name + '.maxTimeout');
 	mod_assert.ok(obj.maxTimeout === undefined ||
-	    obj.timeout < obj.maxTimeout,
-	    name + '.maxTimeout must be > timeout');
+	    obj.timeout <= obj.maxTimeout,
+	    name + '.maxTimeout must be >= timeout');
 	delete (ks.maxTimeout);
 	mod_assert.number(obj.delay, name + '.delay');
 	mod_assert.ok(isFinite(obj.delay), name + '.delay must be finite');
@@ -39,8 +39,8 @@ function assertRecovery(obj, name) {
 	delete (ks.delay);
 	mod_assert.optionalNumber(obj.maxDelay, name + '.maxDelay');
 	mod_assert.ok(obj.maxDelay === undefined ||
-	    obj.delay < obj.maxDelay,
-	    name + '.maxDelay must be > delay');
+	    obj.delay <= obj.maxDelay,
+	    name + '.maxDelay must be >= delay');
 	delete (ks.maxDelay);
 	mod_assert.deepEqual(Object.keys(ks), []);
 }


### PR DESCRIPTION
This is "make prepush" clean on Node v0.12.7.